### PR TITLE
added support for getting information about the previous comic

### DIFF
--- a/models/comic.js
+++ b/models/comic.js
@@ -40,7 +40,7 @@ class Comic {
     /** get comic by id. */
 
     static async get(id) {
-        const results = await db.query(`SELECT * FROM comics WHERE id = $1`, [id]);
+        const results = await db.query(`SELECT * FROM comics WHERE comic_id = $1`, [id]);
 
         let comic = results.rows[0];
 
@@ -48,11 +48,10 @@ class Comic {
             throw new ExpressError(`No such comic with id: ${id}`, 404);
         }
 
+        const emotes = await Comic.getEmoteData(["Laughing", "Clapping", "ROFL", "Grinning", "Clown"], comic.comic_id);
+        comic = { ...comic, emotes: emotes };
+
         comic = new Comic(comic);
-
-        const companyResults = await db.query("SELECT * FROM companies WHERE handle = $1", [comic.company_handle]);
-
-        comic.company = companyResults.rows[0];
 
         return comic;
     }

--- a/routes/comic.js
+++ b/routes/comic.js
@@ -19,6 +19,17 @@ router.get("/latest", async (req, res, next) => {
     }
 });
 
+router.get("/:comic_id", async (req, res, next) => {
+    try {
+        let { comic_id } = req.params;
+        let result = await Comic.get(comic_id);
+        return res.status(200).json({ comic: result });
+    } catch (error) {
+        console.error(error);
+        return next(error);
+    }
+});
+
 router.get("/upload", checkForCookie, async (req, res, next) => {
     try {
         return res.status(200).json({ message: "Thanks for visiting!" });


### PR DESCRIPTION
Added routes/query to get information on the most recent previously uploaded comics. The order of the comics matters when viewing, so this route allows information about the comic that came before the current latest comic to be obtained behind the scenes before the viewer calls for it. This should hopefully result in a faster user experience.