### PR TITLE
potential fix for ws issues

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -9,6 +9,7 @@ function checkForCookie(req, res, next) {
         if (!authCookie) {
             throw new ExpressError("You do not have permission to view this page", 403);
         }
+        console.log(authCookie);
         let cookie = jwt.verify(authCookie, KEY_SECRET);
         res.locals.user = cookie.user;
         res.locals.is_admin = cookie.is_admin;

--- a/websocket.js
+++ b/websocket.js
@@ -15,9 +15,17 @@ const wss = new WebSocket.Server({
     path: "/comic/upload",
     verifyClient: async function (info, callback) {
         try {
-            console.log(info.req.headers);
+            console.log(info.req.headers.cookie);
+            console.log(info.req.cookies);
+            console.log("-----------------------------");
+            console.log(info.req);
+            console.log("-----------------------------");
             const cookie = info.req.headers.cookie.split("authcookie=")[1];
-            let result = await verifyCookie(cookie);
+            console.log("---cookie---", cookie);
+            const newCookie = info.req.headers.cookie.match(/authcookie=(.*)/)[1].split(";")[0];
+            console.log("---newcookie---", newCookie);
+
+            let result = await verifyCookie(newCookie);
             if (!result) {
                 callback(false, 401, "Unauthorized");
             } else {


### PR DESCRIPTION
verifyClient from the ws package exposes cookies differently than I expected. I was lucky to this point that the cookies were sent in a specific order each time, or I would have noticed this sooner. I believe this is why Safari has not been working.